### PR TITLE
Release v1.2.0: Implement collapsible tag list to fix scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2026-01-29
+
+### Added
+
+- A toggle control to expand and collapse the tag filter list in the side panel.
+
+### Changed
+
+- The tag list now defaults to a collapsed state, showing a maximum of 10 tags
+  to conserve vertical space.
+- Active tag filters are now prioritized and remain visible even when the list
+  is collapsed.
+- Updated visual styling for tag chips and panel scrollbars.
+
+### Fixed
+
+- Resolved a layout issue where a large number of tags prevented scrolling
+  within the bookmarks side panel.
+
 ## [v1.1.1] - 2026-01-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-bookmarks",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Bookmark, tag, and quickly find important responses in your Google Gemini conversations.",
   "type": "module",
   "author": "Vandern Rodrigues <hello@vandern.com>",

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -121,3 +121,23 @@ export const deleteBookmark = async (dependencies, bookmarkId) => {
 
   renderUi(dependencies);
 };
+
+/**
+ * Toggles the expansion state of the tag list.
+ * @param {import('./types.js').Dependencies} dependencies
+ */
+export const toggleTagsExpansion = async (dependencies) => {
+  const { stateManager } = dependencies;
+  const currentState = stateManager.getState();
+
+  const newState = {
+    ...currentState,
+    isTagsExpanded: !currentState.isTagsExpanded,
+  };
+
+  stateManager.setState(newState);
+
+  await stateManager.saveStateToStorage();
+
+  renderUi(dependencies);
+};

--- a/src/core/state-manager.js
+++ b/src/core/state-manager.js
@@ -37,7 +37,7 @@ export class StateManager {
    * @returns {import('./types.js').AppState}
    */
   getInitialState() {
-    return { bookmarks: [], activeTagFilters: [] };
+    return { bookmarks: [], activeTagFilters: [], isTagsExpanded: false };
   }
 
   /**

--- a/src/core/types.js
+++ b/src/core/types.js
@@ -12,6 +12,7 @@
  * @typedef {object} AppState
  * @property {Bookmark[]} bookmarks - The list of all bookmarks for the conversation.
  * @property {string[]} activeTagFilters - A list of tags currently used for filtering.
+ * @property {boolean} isTagsExpanded - Whether the tag list is fully expanded.
  */
 
 /**

--- a/src/helpers/smooth-scroll-up.js
+++ b/src/helpers/smooth-scroll-up.js
@@ -29,9 +29,7 @@ export const smoothScrollUp = (scrollContainer) => {
 
   const step = () => {
     const currentScrollTop =
-      scrollContainer === window
-        ? window.scrollY
-        : scrollContainer["scrollTop"];
+      scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
 
     if (currentScrollTop === 0) {
       if (!topTimeoutId) {

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import { getTheme } from "./core/settings";
 import { StateManager } from "./core/state-manager";
 import { checkStorageQuota } from "./core/storage-limiter";
 import { elementSelectors } from "./data/element-selectors";
-import { waitForElement } from "./helpers/wait-for-element";
 import { Logger } from "./shell/logger";
 import { setupEventListeners } from "./shell/setup-event-listeners";
 import { startObserver } from "./shell/start-observer";

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "{{chrome}}.manifest_version": 3,
   "{{firefox}}.manifest_version": 2,
   "name": "Gemini Bookmarks",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "{{firefox}}.browser_specific_settings": {
     "gecko": {
       "id": "{ed3a4a46-9add-4417-a77f-ad0f28102357}",

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -51,7 +51,8 @@ h2 {
   color: var(--color-text-primary);
 }
 
-#loading-state, #empty-state {
+#loading-state,
+#empty-state {
   text-align: center;
   padding: 2rem;
   color: var(--color-text-subtle);
@@ -96,7 +97,8 @@ h2 {
   gap: 4px;
 }
 
-.delete-button, .delete-all-button {
+.delete-button,
+.delete-all-button {
   background-color: var(--color-danger);
   color: #fff;
   border: none;
@@ -108,7 +110,8 @@ h2 {
   transition: background-color 0.2s ease;
 }
 
-.delete-button:hover, .delete-all-button:hover {
+.delete-button:hover,
+.delete-all-button:hover {
   background-color: var(--color-danger-hover);
 }
 
@@ -118,7 +121,8 @@ h2 {
   align-items: center;
 }
 
-.view-button, .export-all-button {
+.view-button,
+.export-all-button {
   background-color: transparent;
   color: var(--color-brand-primary);
   border: 1px solid var(--color-border);
@@ -130,7 +134,8 @@ h2 {
   transition: all 0.2s ease;
 }
 
-.view-button:hover, .export-all-button:hover {
+.view-button:hover,
+.export-all-button:hover {
   background-color: var(--color-brand-primary);
   color: var(--color-brand-text);
   border-color: var(--color-brand-primary);

--- a/src/ui/render-ui.js
+++ b/src/ui/render-ui.js
@@ -1,3 +1,4 @@
+import { toggleTagsExpansion } from "../core/actions";
 import { filterBookmarksByTags, getUniqueTags } from "../core/logic";
 import { createIconElement } from "../helpers/create-icon-element.js";
 import { actionIcons } from "./icons.js";
@@ -15,8 +16,29 @@ export const renderUi = (dependencies) => {
     uiElements.clearAllButton.disabled = currentState.bookmarks.length === 0;
   }
 
-  renderPanelContent({ currentState, uiElements, window });
+  renderPanelContent({ currentState, uiElements, window, stateManager });
   updateAllBookmarkButtonUis({ uiElements, elementSelectors, currentState });
+};
+
+/**
+ * Decides which tags to show based on the expansion state.
+ * @param {string[]} allTags - All unique tags sorted alphabetically.
+ * @param {string[]} activeFilters - The currently active tags.
+ * @param {boolean} isExpanded - Whether the panel is expanded.
+ * @param {number} limit - The number of tags to show when collapsed.
+ */
+const getTagsToRender = (allTags, activeFilters, isExpanded, limit) => {
+  // If expanded, show everything, purely alphabetical.
+  if (isExpanded) {
+    return allTags;
+  }
+
+  // If collapsed, place active tags into the view.
+  const activeTags = allTags.filter((tag) => activeFilters.includes(tag));
+  const inactiveTags = allTags.filter((tag) => !activeFilters.includes(tag));
+  const combined = [...activeTags, ...inactiveTags].slice(0, limit);
+
+  return combined.sort((a, b) => a.localeCompare(b));
 };
 
 /**
@@ -28,13 +50,30 @@ export const renderUi = (dependencies) => {
  */
 const renderPanelContent = (dependencies) => {
   const { currentState, uiElements, window } = dependencies;
+  const { activeTagFilters, isTagsExpanded } = currentState;
 
-  // Render tags
+  const previousScrollTop = uiElements.tagsContainer.scrollTop;
+
+  if (isTagsExpanded) {
+    uiElements.tagsContainer.classList.add("expanded");
+  } else {
+    uiElements.tagsContainer.classList.remove("expanded");
+  }
+
   const uniqueTags = getUniqueTags(currentState);
+  const TAG_LIMIT = 10;
+  const tagsToRender = getTagsToRender(
+    uniqueTags,
+    activeTagFilters,
+    isTagsExpanded,
+    TAG_LIMIT,
+  );
+
+  const showTagsToggleButton = uniqueTags.length > TAG_LIMIT;
 
   uiElements.tagsContainer.replaceChildren();
 
-  uniqueTags.forEach((tag) => {
+  tagsToRender.forEach((tag) => {
     const tagButton = window.document.createElement("button");
 
     tagButton.className = "gb-panel-tag-filter";
@@ -45,8 +84,45 @@ const renderPanelContent = (dependencies) => {
       tagButton.classList.add("active");
     }
 
+    tagButton.addEventListener("mousedown", (e) => e.preventDefault());
+
     uiElements.tagsContainer.appendChild(tagButton);
   });
+
+  if (showTagsToggleButton) {
+    const tagsToggleButton = window.document.createElement("button");
+
+    tagsToggleButton.className = "gb-tags-toggle-button";
+
+    if (isTagsExpanded) {
+      tagsToggleButton.textContent = "Show Less";
+      tagsToggleButton.append(createIconElement(actionIcons.close));
+    } else {
+      const remainingCount = uniqueTags.length - tagsToRender.length;
+
+      const totalActive = activeTagFilters.length;
+      const visibleActive = tagsToRender.filter((t) =>
+        activeTagFilters.includes(t),
+      ).length;
+      const hiddenActiveCount = totalActive - visibleActive;
+
+      if (hiddenActiveCount > 0) {
+        tagsToggleButton.textContent = `+${remainingCount} more (${hiddenActiveCount} active)`;
+        tagsToggleButton.style.fontWeight = "700";
+        tagsToggleButton.style.color = "var(--color-brand-primary)";
+      } else {
+        tagsToggleButton.textContent = `+${remainingCount} more`;
+      }
+    }
+
+    tagsToggleButton.addEventListener("click", () => {
+      toggleTagsExpansion(dependencies);
+    });
+
+    uiElements.tagsContainer.appendChild(tagsToggleButton);
+  }
+
+  uiElements.tagsContainer.scrollTop = previousScrollTop;
 
   // Render bookmarks
   const bookmarksToShow =

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -118,6 +118,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  position: relative;
+  z-index: 20;
+  box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.08);
 }
 
 .gb-panel__header h3 {
@@ -130,26 +134,47 @@
 .gb-panel__bookmarks {
   overflow-y: auto;
   flex-grow: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
 }
 
 .gb-panel__tags {
-  padding: 8px 16px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  transition: max-height 0.2s ease-in-out;
+  max-height: auto;
+}
+
+.gb-panel__tags.expanded {
+  /* Limit expansion to ~45% of the total panel height (450px) */
+  max-height: 200px;
+  /* Enable scrolling only inside the expanded view */
+  overflow-y: auto;
+
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: inset 0 -4px 6px -4px rgba(0,0,0,0.1);
 }
 
 .gb-panel-tag-filter {
   background-color: var(--color-surface);
-  color: var(--color-brand-primary);
+  color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 16px;
-  padding: 4px 12px;
-  font-size: 13px;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: all 0.2 ease;
+  user-select: none;
 }
 
 .gb-panel-tag-filter:hover {
@@ -160,6 +185,35 @@
   background-color: var(--color-brand-primary);
   color: var(--color-brand-text);
   border-color: var(--color-brand-primary);
+}
+
+.gb-tags-toggle-button {
+  background: transparent;
+  border: 1px dashed var(--color-border);
+  color: var(--color-text-subtle);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: fit-content;
+  line-height: normal;
+}
+
+.gb-tags-toggle-button svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 3px;
+}
+
+.gb-tags-toggle-button:hover {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border-style: solid;
 }
 
 .gb-panel__empty-message {


### PR DESCRIPTION
Fix for #4 

Previously, accumulating a large number of tags caused the side panel layout to break, preventing users from scrolling down to reach their bookmarks. The tag list would expand indefinitely, pushing content out of view.

This updates the UI to limit the initial tag display to 10 items. A "Show More" toggle is added to expand the list, and active filters are prioritized in the collapsed view. The tag container now enforces a maximum height to preserve space for the bookmark list.